### PR TITLE
Aspid.MVVM.Unity.Generators 1.1.0

### DIFF
--- a/Aspid.MVVM.Unity.Generators/Aspid.MVVM.Unity.Generators/Generators/ContextMenu/AddBinderContextMenuGenerator.cs
+++ b/Aspid.MVVM.Unity.Generators/Aspid.MVVM.Unity.Generators/Generators/ContextMenu/AddBinderContextMenuGenerator.cs
@@ -11,11 +11,11 @@ using static Aspid.MVVM.Generators.Descriptions.General;
 namespace Aspid.MVVM.Unity.Generators.ContextMenu;
 
 [Generator(LanguageNames.CSharp)]
-public sealed class AddComponentContextMenuGenerator : IIncrementalGenerator
+public sealed class AddBinderContextMenuGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var provider = context.SyntaxProvider.ForAttributeWithMetadataName(AddComponentContextMenuAttribute.FullName, SyntacticPredicate, Find)
+        var provider = context.SyntaxProvider.ForAttributeWithMetadataName(AddBinderContextMenuAttribute.FullName, SyntacticPredicate, Find)
             .Where(foundForSourceGenerator => foundForSourceGenerator.IsNeed)
             .Select((foundForSourceGenerator, _) => foundForSourceGenerator.Container);
         
@@ -32,25 +32,30 @@ public sealed class AddComponentContextMenuGenerator : IIncrementalGenerator
         var declaration = (ClassDeclarationSyntax)context.TargetNode;
         if (context.TargetSymbol is not INamedTypeSymbol symbol) return default;
 
-        if (symbol.HasAnyAttribute(out var attribute, AddComponentContextMenuAttribute))
+        if (symbol.HasAnyAttribute(out var attribute, AddBinderContextMenuAttribute))
         {
             if (attribute!.ConstructorArguments[0].Value is not ITypeSymbol type) return default;
-
-            string? path = null;
             
-            if (attribute.ConstructorArguments.Length > 1)
-                path = attribute.ConstructorArguments[1].Value?.ToString();
-
             var arguments = attribute.NamedArguments;
-            var priority = (int)(arguments.FirstOrDefault(pair => pair.Key == "Priority").Value.Value ?? 100001);
+            var path = arguments.FirstOrDefault(pair => pair.Key == "Path").Value.Value as string;
 
-            return new FoundForGenerator<ContextMenuData>(new ContextMenuData(declaration, symbol, symbol.Name, type.Name, path, priority));
+            if (path is null)
+            {
+                if (symbol.HasAnyAttribute(out var addComponentMenuAttribute, "UnityEngine.AddComponentMenu"))
+                {
+                    path = addComponentMenuAttribute!.ConstructorArguments[0].Value as string;
+
+                    if (path is not null)
+                        path = $"Add {type.Name} Binder" + path.Substring(path.LastIndexOf("/", StringComparison.Ordinal));
+                }
+
+                path ??= $"Add {type.Name} Binder/{symbol.Name}";
+            }
+
+            return new FoundForGenerator<ContextMenuData>(new ContextMenuData(declaration, symbol, symbol.Name, type.Name, path, 100001));
         }
 
         return default;
-
-        string? GetName(string? path) =>
-            path?.Substring(path.LastIndexOf("/", StringComparison.Ordinal) + 1);
     }
 
     private static void GenerateCode(SourceProductionContext context, ContextMenuData data)

--- a/Aspid.MVVM.Unity.Generators/Aspid.MVVM.Unity.Generators/Generators/ContextMenu/AddBinderContextMenuGenerator.cs
+++ b/Aspid.MVVM.Unity.Generators/Aspid.MVVM.Unity.Generators/Generators/ContextMenu/AddBinderContextMenuGenerator.cs
@@ -38,7 +38,9 @@ public sealed class AddBinderContextMenuGenerator : IIncrementalGenerator
             
             var arguments = attribute.NamedArguments;
             var path = arguments.FirstOrDefault(pair => pair.Key == "Path").Value.Value as string;
-
+            var suPath = arguments.FirstOrDefault(pair => pair.Key == "SubPath").Value.Value as string;
+            suPath = suPath is not null ? $"{suPath}/" : string.Empty;
+            
             if (path is null)
             {
                 if (symbol.HasAnyAttribute(out var addComponentMenuAttribute, "UnityEngine.AddComponentMenu"))
@@ -50,6 +52,16 @@ public sealed class AddBinderContextMenuGenerator : IIncrementalGenerator
                 }
 
                 path ??= $"Add {type.Name} Binder/{symbol.Name}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(path) && !string.IsNullOrWhiteSpace(suPath))
+            {
+                var index = path.IndexOf('/');
+                if (index is -1) index = path.Length - 2;
+                
+                index++;
+                if (index >= 0 && index < path.Length)
+                    path = path.Insert(path.IndexOf('/') + 1, suPath);
             }
 
             return new FoundForGenerator<ContextMenuData>(new ContextMenuData(declaration, symbol, symbol.Name, type.Name, path, 100001));

--- a/Aspid.MVVM.Unity.Generators/Aspid.MVVM.Unity.Generators/Generators/Descriptions/Classes.Aspid.cs
+++ b/Aspid.MVVM.Unity.Generators/Aspid.MVVM.Unity.Generators/Generators/Descriptions/Classes.Aspid.cs
@@ -5,6 +5,6 @@ namespace Aspid.MVVM.Generators.Descriptions;
 // ReSharper disable InconsistentNaming
 public static partial class Classes
 {
-    public static readonly AttributeText AddComponentContextMenuAttribute =
-        new ("AddComponentContextMenu", Namespaces.Aspid_MVVM);
+    public static readonly AttributeText AddBinderContextMenuAttribute =
+        new ("AddBinderContextMenu", Namespaces.Aspid_MVVM);
 }

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
     <Target Name="CopyToUnity" AfterTargets="Build" Condition="'$(IsRoslynComponent)' == 'true'">
         <PropertyGroup>
-            <_UnityDestination>$(MSBuildThisFileDirectory)../Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/</_UnityDestination>
+            <_UnityDestination>$(MSBuildThisFileDirectory)../Aspid.MVVM/Assets/Aspid/MVVM/Unity/</_UnityDestination>
         </PropertyGroup>
         <MakeDir Directories="$(_UnityDestination)" />
         <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(_UnityDestination)" SkipUnchangedFiles="true" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,11 @@
+<Project>
+
+    <Target Name="CopyToUnity" AfterTargets="Build" Condition="'$(IsRoslynComponent)' == 'true'">
+        <PropertyGroup>
+            <_UnityDestination>$(MSBuildThisFileDirectory)../Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/</_UnityDestination>
+        </PropertyGroup>
+        <MakeDir Directories="$(_UnityDestination)" />
+        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(_UnityDestination)" SkipUnchangedFiles="true" />
+    </Target>
+
+</Project>


### PR DESCRIPTION
## Summary

`Aspid.MVVM.Unity.Generators` для релиза `Aspid.MVVM 1.1.0`: апгрейд генератора context menu биндеров до `AddBinderContextMenuAttribute` / `AddBinderContextMenuByTypeAttribute` и поддержка `subPath`.

## Changes

- **Upgrade context menu generator** — переименован `ContextMenuGenerator` → `AddBinderContextMenuGenerator`; обновлён под новые атрибуты `AddBinderContextMenuAttribute` / `AddBinderContextMenuByTypeAttribute` с именованным свойством `Path = "..."`. Обновлены `Classes.Aspid.cs`-дескрипторы.
- **Add support for `subPath`** — генератор учитывает дополнительный `SubPath`-сегмент при формировании пути пункта меню.
- **`Directory.Build.targets`** — добавлен общий `CopyToUnity`-таргет (копирование сгенерированной DLL в Unity-проект).
- **Update Unity copy path** — путь обновлён под перенос Unity-проекта в `Aspid.MVVM/` (`Assets/Plugins/Aspid/MVVM/Unity/` → `Assets/Aspid/MVVM/Unity/`).

## Breaking changes

- В коде потребителей `AddComponentContextMenuAttribute` и `AddPropertyContextMenuAttribute` удалены — заменяются `AddBinderContextMenuAttribute` / `AddBinderContextMenuByTypeAttribute` (см. главный PR Aspid.MVVM#25).

## Linked PRs

- Aspid.MVVM — https://github.com/VPDPersonal/Aspid.MVVM/pull/25

## Test plan

- [ ] `dotnet build Aspid.MVVM.Unity.Generators.sln` собирается без ошибок.
- [ ] Перебилд → `Aspid.MVVM.Unity.Generators.dll` обновляется в Unity-пакете по новому пути (`Aspid.MVVM/Assets/Aspid/MVVM/Unity/`).
- [ ] В Unity пункты `Add Binder` / `Add Binder By Type` появляются в context menu для биндеров с `AddBinderContextMenuAttribute` / `AddBinderContextMenuByTypeAttribute`.
- [ ] `SubPath` корректно вставляет дополнительный сегмент в пути пунктов меню.
