### PR TITLE
Update Unity copy path for MVVM folder move

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
     <Target Name="CopyToUnity" AfterTargets="Build" Condition="'$(IsRoslynComponent)' == 'true'">
         <PropertyGroup>
-            <_UnityDestination>$(MSBuildThisFileDirectory)../Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/</_UnityDestination>
+            <_UnityDestination>$(MSBuildThisFileDirectory)../Aspid.MVVM/Assets/Aspid/MVVM/Unity/</_UnityDestination>
         </PropertyGroup>
         <MakeDir Directories="$(_UnityDestination)" />
         <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(_UnityDestination)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
## Summary

- Repoint the `CopyToUnity` target in `Directory.Build.targets` from `Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/` to `Aspid.MVVM/Assets/Aspid/MVVM/Unity/` to match the new MVVM package location in the main repo.
- Coordinated with the matching `Refactor/Move-MVVM-Folder` branch in `Aspid.MVVM` (main repo) — submodule pointer bump lives there.

## Notes for review

- Build-only change; no generator code or generated output is affected.
- Will be merged together with the main-repo PR and the sibling submodule PRs in `Aspid.MVVM.Generators` and `Aspid.MVVM.Analyzers`.